### PR TITLE
#[41]-double-slash-in-urls

### DIFF
--- a/constants.js
+++ b/constants.js
@@ -1,4 +1,5 @@
-export const FORUM_TOPIC = "https://forum.freecodecamp.org/t/";
-export const FORUM_CATEGORY = "https://forum.freecodecamp.org/c/";
+// Do NOT include trailing slashes at the end of URLs in this project
+export const FORUM_TOPIC = "https://forum.freecodecamp.org/t";
+export const FORUM_CATEGORY = "https://forum.freecodecamp.org/c";
 export const FORUM_AVATARS = "https://sea1.discourse-cdn.com/freecodecamp";
 export const FORUM_API = "https://forum-proxy.freecodecamp.rocks/latest";


### PR DESCRIPTION
# Description

Removed some trailing slashes in the `constants.js` and added comment to prevent this from happening in the future.

Fixes #41 

<!-- Please place an x in the [ ] to check off the type of change for this PR -->

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

<!-- Please make sure to go through the entire checklist before requesting a review. Place an x in the [ ] to check off all of the items completed -->

## Checklist

- [x] I have a descriptive title for my PR
- [x] I have linked the issue to this [PR](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [x] I have run the project locally and reviewed the code changes
- [x] My changes generate no new warnings
