### PR TITLE
added recent activity time for each post and centered text for right 3 columns

### DIFF
--- a/helpers.js
+++ b/helpers.js
@@ -11,9 +11,8 @@ export const supportedTopicCategories = {
   3: { longName: "Contributors", name: "contributors" },
 };
 
-export const displayRecentActivity = (bumpedAt) => {
-  const bumpDate = new Date(bumpedAt);
-  const timeDifference = Date.now() - bumpDate.getTime();
+export const formatDateDiff = (recent, old) => {
+  const timeDifference = new Date(recent) - new Date(old);
   const seconds = timeDifference / 1000;
   const minutes = seconds / 60;
   const hours = minutes / 60;

--- a/helpers.js
+++ b/helpers.js
@@ -10,3 +10,28 @@ export const supportedTopicCategories = {
   1: { longName: "General", name: "general" },
   3: { longName: "Contributors", name: "contributors" },
 };
+
+export const displayRecentActivity = (bumpedAt) => {
+  const bumpDate = new Date(bumpedAt);
+  const timeDifference = Date.now() - bumpDate.getTime();
+  const seconds = timeDifference / 1000;
+  const minutes = seconds / 60;
+  const hours = minutes / 60;
+  const days = hours / 24;
+
+  if (seconds < 60) return "1m";
+  if (minutes < 60) return Math.round(minutes) + "m";
+  if (hours < 24) return Math.round(hours) + "h";
+  if (days < 30) return Math.round(days) + "d";
+  if (bumpDate.getFullYear() != new Date(Date.now()).getFullYear()) {
+    const formattedDate = new Intl.DateTimeFormat("default", {
+      month: "short",
+      year: "2-digit",
+    }).format(bumpDate.getTime());
+    return formattedDate.substring(0, 3) + " '" + formattedDate.substring(4, 6);
+  }
+  return new Intl.DateTimeFormat("default", {
+    month: "short",
+    day: "numeric",
+  }).format(bumpDate.getTime()); // ex: Nov 15
+};

--- a/index.js
+++ b/index.js
@@ -5,7 +5,7 @@ import {
   FORUM_API,
 } from "./constants.js";
 
-import { supportedTopicCategories } from "./helpers.js";
+import { supportedTopicCategories, displayRecentActivity } from "./helpers.js";
 
 const copyright = document.getElementById("copyright");
 const postsContainer = document.getElementById("posts-container");
@@ -60,24 +60,6 @@ const displayPost = (post) => {
     return summary;
   };
 
-  const displayRecentActivity = () => {
-    const bumpedAt = new Date(post.bumped_at);
-    const timeDifference = Date.now() - bumpedAt.getTime();
-    const seconds = timeDifference / 1000;
-    const minutes = seconds / 60;
-    const hours = minutes / 60;
-    const days = hours / 24;
-
-    if (seconds < 60) return "1m";
-    if (minutes < 60) return Math.round(minutes) + "m";
-    if (hours < 24) return Math.round(hours) + "h";
-    if (days < 30) return Math.round(days) + "d";
-    return new Intl.DateTimeFormat("default", {
-      month: "short",
-      day: "numeric",
-    }).format(bumpedAt.getTime()); // ex: Nov 15
-  };
-
   let postRow = `
   <tr> 
     <td>
@@ -99,7 +81,7 @@ const displayPost = (post) => {
     </td>
     <td class='post-statistic'></td>
     <td class='post-statistic'></td>
-    <td class='post-statistic'>${displayRecentActivity()}</td>
+    <td class='post-statistic'>${displayRecentActivity(post.bumped_at)}</td>
   </tr>`;
   postsContainer.innerHTML += postRow;
 };

--- a/index.js
+++ b/index.js
@@ -5,7 +5,7 @@ import {
   FORUM_API,
 } from "./constants.js";
 
-import { supportedTopicCategories, displayRecentActivity } from "./helpers.js";
+import { supportedTopicCategories, formatDateDiff } from "./helpers.js";
 
 const copyright = document.getElementById("copyright");
 const postsContainer = document.getElementById("posts-container");

--- a/index.js
+++ b/index.js
@@ -81,7 +81,7 @@ const displayPost = (post) => {
     </td>
     <td class='post-statistic'></td>
     <td class='post-statistic'></td>
-    <td class='post-statistic'>${displayRecentActivity(post.bumped_at)}</td>
+    <td class='post-statistic'>${formatDateDiff(Date.now(), post.bumped_at)}</td>
   </tr>`;
   postsContainer.innerHTML += postRow;
 };

--- a/index.js
+++ b/index.js
@@ -36,6 +36,7 @@ fetch(FORUM_API)
   .finally(() => {
     isLoading = false;
   });
+console.log(forumData);
 
 const displayPostList = (postList) => {
   postList
@@ -59,6 +60,24 @@ const displayPost = (post) => {
     return summary;
   };
 
+  const displayRecentActivity = () => {
+    const bumpedAt = new Date(post.bumped_at);
+    const timeDifference = Date.now() - bumpedAt.getTime();
+    const seconds = timeDifference / 1000;
+    const minutes = seconds / 60;
+    const hours = minutes / 60;
+    const days = hours / 24;
+
+    if (seconds < 60) return "1m";
+    if (minutes < 60) return Math.round(minutes) + "m";
+    if (hours < 24) return Math.round(hours) + "h";
+    if (days < 30) return Math.round(days) + "d";
+    return new Intl.DateTimeFormat("default", {
+      month: "short",
+      day: "numeric",
+    }).format(bumpedAt.getTime()); // ex: Nov 15
+  };
+
   let postRow = `
   <tr> 
     <td>
@@ -78,9 +97,9 @@ const displayPost = (post) => {
       </div>
       ${ifSummaryDisplay()}
     </td>
-    <td></td>
-    <td></td>
-    <td></td>
+    <td class='post-statistic'></td>
+    <td class='post-statistic'></td>
+    <td class='post-statistic'>${displayRecentActivity()}</td>
   </tr>`;
   postsContainer.innerHTML += postRow;
 };

--- a/styles.css
+++ b/styles.css
@@ -150,6 +150,10 @@ a {
   text-decoration: underline;
 }
 
+.post-statistic {
+  text-align: center;
+}
+
 .topics {
   width: 70%;
   text-align: left;


### PR DESCRIPTION
# Description

I added 'displayRecentActivity' function inside of displayPost. This function returns a formatted string representing the post's most recent activity as provided by post.bumped_at. I then called displayRecentActivity inside the fourth column of the table row returned by displayPost. Finally, I added a CSS class 'post-statistic', which centers the text, and applied this class the right three columns of the row.

Fixes jdwilkin4/fcc-forum-clone#24
<!-- Please place an x in the [ ] to check off the type of change for this PR -->

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Chore items (this includes basic clean up of files, or updates to packages)
- [ ] Updates to documentation

<!-- Please make sure to go through the entire checklist before requesting a review. Place an x in the [ ] to check off all of the items completed -->

## Checklist

- [X] I have a descriptive title for my PR
- [X] I have linked the issue to this [PR](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [X] I have run the project locally and reviewed the code changes
- [X] My changes generate no new warnings
